### PR TITLE
Fix duplicate routes, imports and transcript logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p static && \
     chmod -R 755 static && \
     ls -la static/  # Debug: List copied files
 
-# Expose port 8000
+# Expose port 8080
 EXPOSE 8080
 
 # Command to run the application with debug logging

--- a/app/export_utils.py
+++ b/app/export_utils.py
@@ -36,9 +36,10 @@ def export_to_pdf(content: str) -> Response:
                     if img_data.startswith('data:image'):
                         # Remove header from base64 string
                         img_data = img_data.split(',')[1]
-                        # Save image to temporary file
+                        # Save image to temporary buffer with name attribute
                         img_temp = io.BytesIO(base64.b64decode(img_data))
-                        pdf.image(img_temp, x=10, w=190)
+                        img_temp.name = 'image.png'
+                        pdf.image(img_temp, x=10, w=190, type='PNG')
                 except Exception as e:
                     print(f"Error processing image: {e}")
             else:


### PR DESCRIPTION
## Summary
- clean duplicate asyncio and /api/config definitions
- switch transcript retrieval to async helper with logging
- improve PDF export image handling
- tweak Dockerfile port comment

## Testing
- `python -m py_compile transcript_retriever.py app/export_utils.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68430f165b6c832f9601433ba733c122